### PR TITLE
Quick fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,7 +671,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zat"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aho-corasick",
  "ansi_term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zat"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["Sanj Sahayam"]
 

--- a/src/error/error.rs
+++ b/src/error/error.rs
@@ -244,7 +244,7 @@ impl std::fmt::Display for ZatError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
       let string_rep = match self {
         ZatError::UserConfigError(error)          => ZatError::print_formatted_error("Got a configuration error", error),
-        ZatError::VariableFileError(error)        => ZatError::print_formatted_error("Got a error processing variables", error),
+        ZatError::VariableFileError(error)        => ZatError::print_formatted_error("Got an error processing variables", error),
         ZatError::TemplateProcessingError(error)  => ZatError::print_formatted_error("There was an error running the template", error),
         ZatError::PostProcessingError(error)      => ZatError::print_formatted_error("There was an error running the post processor", error),
       };

--- a/src/error/error.rs
+++ b/src/error/error.rs
@@ -216,25 +216,25 @@ impl ZatError {
   pub fn post_processing_hook_failed(path: &str, error: String) -> ZatError {
     ZatError::PostProcessingError(
       PostProcessingErrorReason::ExecutionError(
-        s!("Shell hook `{}` failed with an error.", path),
+        s!("Shell hook '{}' failed with an error.", path),
         Some(error),
-        s!("Please ensure the shell hook file `{}` exists and is executable.", path))
+        s!("Please ensure the shell hook file '{}' exists and is executable.", path))
     )
   }
 
   pub fn post_processing_hook_completed_with_non_zero_status(path: &str, status: i32) -> ZatError {
     ZatError::PostProcessingError(
       PostProcessingErrorReason::NonZeroStatusCode(
-        s!("Shell hook `{}` failed with status code {}. The shell hook failed with a non-zero error code signifying an error.", path, status),
-        s!("Please check the logs above for why the shell hook failed. Try running the shell hook file `{}` manually by itself on the output to iterate on the error.", path))
+        s!("Shell hook '{}' failed with status code {}. The shell hook failed with a non-zero error code signifying an error.", path, status),
+        s!("Please check the logs above for why the shell hook failed. Try running the shell hook file '{}' manually by itself on the output to iterate on the error.", path))
     )
   }
 
   pub fn post_processing_hook_was_shutdown(path: &str) -> ZatError {
     ZatError::PostProcessingError(
       PostProcessingErrorReason::ProcessInterrupted(
-        s!("Shell hook `{}` was shutdown. Some other process killed the shell hook process.", path),
-        s!("Try running the shell hook file `{}` manually on the output.", path))
+        s!("Shell hook '{}' was shutdown. Some other process killed the shell hook process.", path),
+        s!("Try running the shell hook file '{}' manually on the output.", path))
     )
   }
 }

--- a/src/logging/logger.rs
+++ b/src/logging/logger.rs
@@ -9,6 +9,10 @@ impl Logger {
     p!("\n{}", Yellow.paint(message))
   }
 
+  pub (crate) fn coloured(message: &str) {
+    p!("\n{}", message)
+  }
+
   pub (crate) fn warn(message: &str) {
     p!("\n{}", Red.paint(message))
   }

--- a/src/logging/logger.rs
+++ b/src/logging/logger.rs
@@ -1,5 +1,5 @@
 use std::{println as p, eprintln as e};
-use ansi_term::Color::{Yellow, Red};
+use ansi_term::Color::{Yellow, Red, Green};
 
 pub struct Logger;
 
@@ -7,6 +7,10 @@ impl Logger {
 
   pub (crate) fn info(message: &str) {
     p!("\n{}", Yellow.paint(message))
+  }
+
+  pub (crate) fn success(message: &str) {
+    p!("\n{}", Green.paint(message))
   }
 
   pub (crate) fn coloured(message: &str) {

--- a/src/logging/logger.rs
+++ b/src/logging/logger.rs
@@ -1,5 +1,5 @@
 use std::{println as p, eprintln as e};
-use ansi_term::Color::{Yellow, Red, Green};
+use ansi_term::Colour::{self, Yellow, Red, Green};
 
 pub struct Logger;
 
@@ -7,6 +7,10 @@ impl Logger {
 
   pub (crate) fn info(message: &str) {
     p!("\n{}", Yellow.paint(message))
+  }
+
+  pub (crate) fn info_str(message: &str) -> String {
+    Yellow.paint(message).to_string()
   }
 
   pub (crate) fn success(message: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,12 @@ fn run_zat() -> ZatAction {
       // Run post-processor if one exists
       ShellHook.run(&user_config)?;
 
-      Logger::info(s!("Extracted template to '{}'", &user_config.target_dir.path).as_str())
+      Logger::coloured(
+        &s!("{}{}{}",
+          Logger::info_str("Extracted template to '"),
+          &user_config.target_dir.path.as_str(),
+          Logger::info_str("'")
+        ))
     },
     TemplateVariableReview::Rejected => Logger::warn("The user rejected the variables.")
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ use crate::post_processor::ShellHook;
 
 use logging::VerboseLogger;
 use logging::Logger;
+use std::format as s;
 
 
 fn main() -> ExitCode {
@@ -76,7 +77,9 @@ fn run_zat() -> ZatAction {
       DefaultProcessTemplates.process_templates(user_config.clone(), tokenized_key_expanded_variables)?;
 
       // Run post-processor if one exists
-      ShellHook.run(&user_config)?
+      ShellHook.run(&user_config)?;
+
+      Logger::info(s!("Extracted template to '{}'", &user_config.target_dir.path).as_str())
     },
     TemplateVariableReview::Rejected => Logger::warn("The user rejected the variables.")
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use std::format as s;
 fn main() -> ExitCode {
   match run_zat() {
     Ok(_) => {
-      Logger::info("Zat completed successfully.");
+      Logger::success("Zat completed successfully.");
       ExitCode::SUCCESS
     },
     Err(error) => {

--- a/src/processor/default_process_templates.rs
+++ b/src/processor/default_process_templates.rs
@@ -15,7 +15,7 @@ use super::DefaultEnrichedTemplateFileProcessor;
 use super::AhoCorasickTokenReplacer;
 use super::FileTraverser;
 use crate::config::{UserConfig, TemplateFilesDir};
-use std::{format as s, println};
+use std::format as s;
 
 pub struct DefaultProcessTemplates;
 

--- a/src/templates/default_template_config_validator.rs
+++ b/src/templates/default_template_config_validator.rs
@@ -82,6 +82,7 @@ impl UserTemplateVariableValidator for Cli {
 }
 
 impl Cli {
+
   fn print_user_input(user_variables: &HashMap<UserVariableKey, UserVariableValue>) {
     Logger::info("Please confirm the variable mappings below are correct.");
 
@@ -92,7 +93,14 @@ impl Cli {
 
   fn check_user_input() -> UserVariablesValidity {
     // Check if variables are ok
-    Logger::info("Press [y]es if correct, and any other key if not.");
+    Logger::coloured(
+      &s!("{}{}{}",
+        Yellow.paint("Press "),
+        Style::new().bold().paint("y"),
+        Yellow.paint(" if correct, and any other key if not.")
+      )
+    );
+
     let mut user_response = String::new();
     let stdin = std::io::stdin();
     let mut handle = stdin.lock();

--- a/tests/errors_integration_tests.rs
+++ b/tests/errors_integration_tests.rs
@@ -47,7 +47,7 @@ fn error_message_on_missing_variables_file() -> Result<(), Box<dyn std::error::E
 
   let error_parts =
     ErrorParts::new(
-      "Got a error processing variables".to_owned(),
+      "Got an error processing variables".to_owned(),
       s!("Variable file '{}/.variables.zat-prompt' does not exist. Zat uses this file to retrieve tokens that will be replaced when rendering the templates.", source_directory),
       s!("Please create the variable file '{}/.variables.zat-prompt' with the required tokens. See `zat -h` for more details.", source_directory),
     );
@@ -63,7 +63,7 @@ fn error_message_on_non_json_variables_file() -> Result<(), Box<dyn std::error::
 
   let error_parts =
     ErrorParts::new(
-      "Got a error processing variables".to_owned(),
+      "Got an error processing variables".to_owned(),
       s!("Variable file '{}/.variables.zat-prompt' could not be decoded as JSON into the expected format. It failed decoding with this error: invalid type: integer `123`, expected a sequence at line 1 column 3. Zat uses this file to retrieve tokens that will be replaced when rendering the templates.", source_directory),
       s!("Make the variable file '{}/.variables.zat-prompt' is a valid JSON file in the format required by Zat. See `zat -h` for more details on the format", source_directory),
     );
@@ -119,7 +119,7 @@ fn error_message_on_no_variables_defined() -> Result<(), Box<dyn std::error::Err
 
   let error_parts =
     ErrorParts::new(
-      "Got a error processing variables".to_owned(),
+      "Got an error processing variables".to_owned(),
       s!("Variable file '{}/.variables.zat-prompt' does not define any variables. The purpose of Zat is to provide a templating tool to customise frequently used file structures. It does this by replacing variables defined in the file '{}/.variables.zat-prompt' on file and directory names of templates as well as within '.tmpl' files. If you want to simply copy a file structure use 'cp' instead.", source_directory, source_directory),
       s!("Please define at least one variable in the variable file '{}/.variables.zat-prompt'.", source_directory),
     );

--- a/tests/errors_integration_tests.rs
+++ b/tests/errors_integration_tests.rs
@@ -3,7 +3,7 @@ use file_differ::print_diff;
 use tempfile::tempdir;
 use predicates::prelude::*;
 use format as s;
-use std::{path::PathBuf, print, println};
+use std::println;
 
 mod file_differ;
 
@@ -156,8 +156,8 @@ fn error_message_on_shell_hook_returning_non_zero_result() -> Result<(), Box<dyn
   let error_parts =
     ErrorParts::new(
       "There was an error running the post processor".to_owned(),
-      s!("Shell hook `{}/shell-hook.zat-exec` failed with status code 1. The shell hook failed with a non-zero error code signifying an error.", source_directory),
-      s!("Please check the logs above for why the shell hook failed. Try running the shell hook file `{}/shell-hook.zat-exec` manually by itself on the output to iterate on the error.", source_directory),
+      s!("Shell hook '{}/shell-hook.zat-exec' failed with status code 1. The shell hook failed with a non-zero error code signifying an error.", source_directory),
+      s!("Please check the logs above for why the shell hook failed. Try running the shell hook file '{}/shell-hook.zat-exec' manually by itself on the output to iterate on the error.", source_directory),
     );
 
   let input = &["YouOnlyLiveOnce", "y"];
@@ -174,9 +174,9 @@ fn error_message_on_shell_hook_not_executable() -> Result<(), Box<dyn std::error
   let error_parts =
     ErrorParts::with_exception(
       "There was an error running the post processor".to_owned(),
-      s!("Shell hook `{}/shell-hook.zat-exec` failed with an error.", source_directory),
+      s!("Shell hook '{}/shell-hook.zat-exec' failed with an error.", source_directory),
       "Permission denied (os error 13)".to_owned(),
-      s!("Please ensure the shell hook file `{}/shell-hook.zat-exec` exists and is executable.", source_directory),
+      s!("Please ensure the shell hook file '{}/shell-hook.zat-exec' exists and is executable.", source_directory),
     );
 
   let input = &["YouOnlyLiveOnce", "y"];


### PR DESCRIPTION
Added some quick fixes.

- Fixed typo on variable-related error messages.
- Used one type of quote (') for path messages.
- Made variable confirmation letter standout by changing its colour relative to the surrounding text.
- Made the success message standout by changing its colour relative to the surrounding text.
- Made the target directory path in the success output standout by changing its colour relative to the surrounding text.
![](https://media.giphy.com/media/xnb3mGfcM2O4uLjt8c/giphy.gif)